### PR TITLE
fix collateralization ration for riskpool

### DIFF
--- a/scripts/product.py
+++ b/scripts/product.py
@@ -119,7 +119,7 @@ class GifRiskpool(object):
 
         self.riskpool = riskpoolContractClass.deploy(
             s2b(name),
-            sumOfSumInsuredCap,
+            collateralization,
             erc20Token,
             riskpoolWallet,
             instance.getRegistry(),


### PR DESCRIPTION
I found out about this issue when I compared the product script for the sandbox project against ayii_product for the gif-contracts project. After this fix the SUM_OF_SUM_INSURED_CAP_DEFAULT is unused. I left it in the code since I couldn't understand the purpose of such constant.